### PR TITLE
Removing build parallelizem

### DIFF
--- a/build/docker/bin/Dockerfile
+++ b/build/docker/bin/Dockerfile
@@ -39,7 +39,7 @@ RUN echo -n "GOPATH: " && echo $GOPATH
 
 # install rocksdb
 RUN cd /opt && git clone -b $ROCKSDB_VERSION --depth 1 https://github.com/facebook/rocksdb.git
-RUN cd /opt/rocksdb && CFLAGS=-fPIC CXXFLAGS=-fPIC PORTABLE=$PORTABLE_ROCKSDB make -j 4 release
+RUN cd /opt/rocksdb && CFLAGS=-fPIC CXXFLAGS=-fPIC PORTABLE=$PORTABLE_ROCKSDB make release
 RUN strip /opt/rocksdb/ldb /opt/rocksdb/sst_dump && \
     cp /opt/rocksdb/ldb /opt/rocksdb/sst_dump /build
 


### PR DESCRIPTION
Building rocks db requires cpu / ram, that might overload runners. Decreasing this number increases the build time, but should not be a problem as we will not build that often